### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Azure IoT Hub client library for ESP8266 that specifically uses MQTT p
 category=Communication
 url=https://github.com/andriyadi/AzureIoTHubMQTTClient
 architectures=esp8266
+depends=ArduinoJson, Time, Ethernet, WiFi101


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format